### PR TITLE
Add -i option to specify private key.

### DIFF
--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"errors"
+	"os"
 
 	"github.com/docker/go-plugins-helpers/volume"
 	"github.com/sirupsen/logrus"
@@ -45,7 +46,7 @@ var dockerCmd = &cobra.Command{
 			Root:       viper.GetString("root"),
 			MountPoint: args[0],
 			SSHServer:  viper.GetString("address"),
-			SSHConfig:  fs.NewConfig(viper.GetString("username"), viper.GetString("password")),
+			SSHConfig:  fs.NewConfig(viper.GetString("username"), viper.GetString("password"), viper.GetString("private-key")),
 		})
 		if err != nil {
 			logrus.WithError(err).Fatal("driver init failed")
@@ -80,5 +81,6 @@ func init() {
 	dockerCmd.Flags().StringP("username", "u", "root", "ssh username")
 	dockerCmd.Flags().StringP("password", "p", "", "ssh password")
 	dockerCmd.Flags().StringP("root", "r", "/tmp", "remote root")
+	dockerCmd.Flags().StringP("private-key", "i", os.Getenv("HOME")+`/.ssh/id_rsa`, "path to private ssh key")
 	dockerCmd.Flags().StringP("socket", "s", "/run/docker/plugins/ssh.sock", "socket address to communicate with docker")
 }

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -41,7 +41,7 @@ var mountCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		config := fs.NewConfig(viper.GetString("username"), viper.GetString("password"))
+		config := fs.NewConfig(viper.GetString("username"), viper.GetString("password"), viper.GetString("private-key"))
 		logrus.WithField("address", viper.GetString("address")).Info("creating FUSE client for SSH Server")
 
 		fs, err := fs.New(config, args[0], viper.GetString("address"), viper.GetString("root"))
@@ -76,4 +76,5 @@ func init() {
 	mountCmd.Flags().StringP("username", "u", "root", "ssh username")
 	mountCmd.Flags().StringP("password", "p", "", "ssh password")
 	mountCmd.Flags().StringP("root", "r", "/opt", "ssh root")
+	mountCmd.Flags().StringP("private-key", "i", os.Getenv("HOME")+`/.ssh/id_rsa`, "path to private ssh key")
 }

--- a/fs/utils.go
+++ b/fs/utils.go
@@ -18,16 +18,15 @@ import (
 	"golang.org/x/crypto/ssh"
 	"log"
 	"net"
-	"os"
 )
 
 // NewConfig creates a new config
-func NewConfig(user, password string) *ssh.ClientConfig {
+func NewConfig(user, password string, privateKeyPath string) *ssh.ClientConfig {
 	auth := []ssh.AuthMethod{
 		ssh.Password(password),
 	}
 
-	publicKey, err := PublicKeyFile(os.Getenv("HOME") + `/.ssh/id_rsa`)
+	publicKey, err := PublicKeyFile(privateKeyPath)
 	if err == nil {
 		auth = append(auth, publicKey)
 	} else {


### PR DESCRIPTION
Allow the private key to be specified using the `-i` or `--private-key` flag. Defaults to `~/.ssh/id_rsa`.